### PR TITLE
Add release options

### DIFF
--- a/discogs_cli/completions.py
+++ b/discogs_cli/completions.py
@@ -18,22 +18,26 @@ ARGS_OPTS_LOOKUP = {
     },
     'master': {
         'args': '1',
-        'opts': '',
+        'opts': ''
     },
     'release': {
         'args': '1',
-        'opts': '',
+        'opts': [
+            '--exclude (personnel|tracklist|notes)',
+            '--include (personnel|tracklist|notes)'
+        ]
     },
     'search': {
         'args': '"query string"',
         'opts': [
             '--lookup (artist|label|release)',
-        ],
+        ]
     },
 }
 META_LOOKUP = {
     '1': 'id: int - discogs ID to retrieve',
     '--lookup': '(artist|label|release)',
-    '"(artist|label|release)"': 'Type of query to perform',
+    '--exclude': '(personnel|tracklist|notes)',
+    '--include': '(personnel|tracklist|notes)'
 }
 META_LOOKUP.update(SUBCOMMANDS)

--- a/discogs_cli/discogs.py
+++ b/discogs_cli/discogs.py
@@ -287,7 +287,6 @@ class Release(Discogs):
     def show(self):
         out = []
         year = self.discogs.year
-        self.discogs.images
         extraartists = self.discogs.data["extraartists"]
         out.append('{artists} - {title}'.format(artists=','.join(
             self._artists(self.discogs.data['artists'])),
@@ -319,9 +318,7 @@ class Release(Discogs):
         click.echo('\n'.join(out), color=True)
 
     def show_extra(self,exclude,include,out):
-        personnel = True
-        tracklist = True
-        notes = True
+        personnel,tracklist,notes = True,True,True
         if "personnel" in exclude:
             personnel = False
         elif "tracklist" in exclude:

--- a/discogs_cli/discogs.py
+++ b/discogs_cli/discogs.py
@@ -309,8 +309,11 @@ class Release(Discogs):
         out.append(self.clabel('Year:') + '     {year}'.format(year=year))
         out.append(self.clabel('Genre:') + '    {genre}'.format(genre=', '.join(
             self.discogs.genres)))
-        out.append(self.clabel('Style:') + '    {style}'.format(style=', '.join(
-            self.discogs.styles)))
+        try:
+            out.append(self.clabel('Style:') + '    {style}'.format(style=', '.join(
+                self.discogs.styles)))
+        except:
+            print("Style info not available.")
         out.append(self.clabel('Rating:') + '   {rating}/5'.format(
             rating=self.discogs.data.get('community', {}).get('rating',
                     {}).get('average'))) 

--- a/discogs_cli/discogs.py
+++ b/discogs_cli/discogs.py
@@ -276,16 +276,19 @@ class Release(Discogs):
     :param release_id: A Discogs.com release id.
     """
 
-    def __init__(self, release_id):
+    def __init__(self, release_id, exclude="None", include="All"):
         super(Release, self).__init__()
         self.release_id = release_id
-
         self.discogs = self.client.release(self.release_id)
+        self.exclude = exclude
+        self.include = include
+
 
     def show(self):
         out = []
         year = self.discogs.year
-
+        self.discogs.images
+        extraartists = self.discogs.data["extraartists"]
         out.append('{artists} - {title}'.format(artists=','.join(
             self._artists(self.discogs.data['artists'])),
             title=self.discogs.data['title']))
@@ -311,13 +314,41 @@ class Release(Discogs):
             self.discogs.styles)))
         out.append(self.clabel('Rating:') + '   {rating}/5'.format(
             rating=self.discogs.data.get('community', {}).get('rating',
-                    {}).get('average')))
-        out.append(self._separator('Tracklist'))
-        for t in self.discogs.data['tracklist']:
-            duration = '   {0}'.format(t.get('duration'))
-            out.append('{pos}\t{title} {dur}'.format(
-                pos=t['position'], title=t['title'], dur=duration))
-
-        out.append(self._separator('Notes'))
-        out.append(self.discogs.data.get('notes', 'None.'))
+                    {}).get('average'))) 
+        out = self.show_extra(self.exclude,self.include,out)
         click.echo('\n'.join(out), color=True)
+
+    def show_extra(self,exclude,include,out):
+        personnel = True
+        tracklist = True
+        notes = True
+        if "personnel" in exclude:
+            personnel = False
+        elif "tracklist" in exclude:
+            tracklist = False
+        elif "notes" in exclude:
+            notes = False
+        elif "personnel" in include:
+            tracklist,notes = False,False
+        elif "tracklist" in include:
+            personnel,notes = False,False
+        elif "notes" in include:
+            personnel,tracklist = False,False
+
+        if personnel is True:
+            out.append(self._separator('Personnel'))
+            for t in self.discogs.data['extraartists']:
+                name = t["name"]
+                role = t["role"]
+                out.append(self.clabel('{role}: '.format(role=role)) + ' {name}'.format(
+                    name=name))
+        if tracklist is True:
+            out.append(self._separator('Tracklist'))
+            for t in self.discogs.data['tracklist']:
+                duration = '   {0}'.format(t.get('duration'))
+                out.append('{pos}\t{title} {dur}'.format(
+                    pos=t['position'], title=t['title'], dur=duration))
+        if notes is True:      
+            out.append(self._separator('Notes'))
+            out.append(self.discogs.data.get('notes', 'None.'))
+        return out

--- a/discogs_cli/main_cli.py
+++ b/discogs_cli/main_cli.py
@@ -32,9 +32,11 @@ def label(label_id):
 
 @cli.command('release')
 @click.argument('release_id')
-def release(release_id):
+@click.option('--exclude', default="None")
+@click.option('--include', default="All")
+def release(release_id,exclude,include):
     """Retrieve a single release from the discogs database."""
-    r = Release(release_id)
+    r = Release(release_id,exclude=exclude,include=include)
 
     try:
         r.show()


### PR DESCRIPTION
I've added --include and --exclude options for the release command. This allows the user to include or exclude what I call 'extra release information' (personnel, tracklist, and notes). Additionally, the default release output includes personnel information. 